### PR TITLE
New syntax for enable_dpcd_backlight in i915

### DIFF
--- a/tuxedo.sh
+++ b/tuxedo.sh
@@ -318,6 +318,9 @@ task_wallpaper_test() {
 }
 
 task_misc() {
+    #i915
+    echo "options i915 enable_dpcd_backlight" >> /etc/modprobe.d/tuxedo-i915.conf
+    
     case "$lsb_dist_id" in
         Ubuntu)
             if ! [ -x "$(which gsettings)" ]; then
@@ -336,11 +339,14 @@ task_misc() {
             if [ "$lsb_release" == "18.04" ] && gsettings writable org.gnome.desktop.peripherals.touchpad click-method; then
                 gsettings set org.gnome.desktop.peripherals.touchpad click-method areas
             fi
+            
+            #New syntax for parameter enable_dpcd_backlight in i915
+            if [ "$lsb_release" == "20.04" ]; then
+                sed -i 's/enable_dpcd_backlight$/enable_dpcd_backlight=1/' /etc/modprobe.d/tuxedo-i915.conf
+            fi         
 EOSU
             ;;
     esac
-    #i915
-    echo "options i915 enable_dpcd_backlight" >> /etc/modprobe.d/tuxedo-i915.conf
 }
 
 task_misc_test() {


### PR DESCRIPTION
Hello,

Tested in Ubuntu Focal 20.04 with InfinityBook Pro 15v5 : I get a bad parameter at boot with the syntax `options i915 enable_dpcd_backlight`, and it's not possible to change the brightness.

The new syntax is : 

```
$ modinfo -p i915 | grep dpcd     
enable_dpcd_backlight:Enable support for DPCD backlight control(-1=use per-VBT LFP backlight type setting, 0=disabled [default], 1=enabled) (int)
```

( int instead of bool ).

So I suggest to replace the line in `/etc/modprobe.d/tuxedo-i915.conf` with sed only if the distribution / release is Ubuntu Focal ( I didn't try it with openSuse ).